### PR TITLE
ci: fix wiring-scope workflow shallow fetch

### DIFF
--- a/.github/workflows/require-wiring-scope.yml
+++ b/.github/workflows/require-wiring-scope.yml
@@ -10,11 +10,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect runtime-adjacent changes
         id: changes
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin ${{ github.base_ref }}
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           echo "$CHANGED" > changed_files.txt
           echo "changed_files<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes a shallow-fetch issue in .github/workflows/require-wiring-scope.yml where `git diff origin/<base>...HEAD` could fail with "fatal: origin/<base>...HEAD: no merge base" under default fetch-depth=1.

Change:
- Set checkout `fetch-depth: 0`
- Remove `--depth=1` from the base branch fetch

Result: merge-base computation is reliable; wiring-scope check can classify runtime-adjacent changes consistently.
