### PR TITLE
ci: run branch-protection symmetry guard on all PRs

### DIFF
--- a/.github/workflows/guard-branch-protection-pairs.yml
+++ b/.github/workflows/guard-branch-protection-pairs.yml
@@ -3,8 +3,6 @@ name: Guard Branch Protection Config Pair
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - ".github/branch-protection/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes paths filter so the symmetry guard runs on every PR (safe for required status checks). XOR enforcement unchanged.