### PR TITLE
chore: include symmetry guard in branch protection contexts

### DIFF
--- a/.github/branch-protection/solo.json
+++ b/.github/branch-protection/solo.json
@@ -1,7 +1,7 @@
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["smoke-pr", "wiring-scope"]
+    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {

--- a/.github/branch-protection/team.json
+++ b/.github/branch-protection/team.json
@@ -1,7 +1,7 @@
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["smoke-pr", "wiring-scope"]
+    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {


### PR DESCRIPTION
Adds required check string Guard solo.json <-> team.json symmetry to required_status_checks.contexts in both solo.json and team.json so policy-as-code matches live branch protection.