### PR TITLE
ci: fix verify-branch-protection workflow dispatch

### DIFF
--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -1,6 +1,6 @@
 name: Verify Branch Protection (solo mode)
 
-on:
+"on":
   push:
     paths:
       - ".github/branch-protection/**"


### PR DESCRIPTION
Quotes the top-level on: key ("on":) to avoid YAML parsing edge-cases that can make GitHub treat the workflow as invalid (no jobs / workflow_dispatch not recognized). No logic changes.