### PR TITLE
policy: require both BP symmetry checks (Phase B)

### DIFF
--- a/.github/branch-protection/solo.json
+++ b/.github/branch-protection/solo.json
@@ -1,7 +1,7 @@
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry"]
+    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry", "Guard solo-team BP symmetry"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {

--- a/.github/branch-protection/team.json
+++ b/.github/branch-protection/team.json
@@ -1,7 +1,7 @@
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry"]
+    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry", "Guard solo-team BP symmetry"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {


### PR DESCRIPTION
Phase B: update solo/team branch-protection configs to require both the legacy symmetry check and the new 'Guard solo-team BP symmetry' check (alongside smoke-pr + wiring-scope).