### PR TITLE
policy: drop legacy BP symmetry context (Phase C3)

### DIFF
--- a/.github/branch-protection/solo.json
+++ b/.github/branch-protection/solo.json
@@ -1,7 +1,7 @@
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry", "Guard solo-team BP symmetry"]
+    "contexts": ["smoke-pr", "wiring-scope", "Guard solo-team BP symmetry"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {

--- a/.github/branch-protection/team.json
+++ b/.github/branch-protection/team.json
@@ -1,7 +1,7 @@
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["smoke-pr", "wiring-scope", "Guard solo.json <-> team.json symmetry", "Guard solo-team BP symmetry"]
+    "contexts": ["smoke-pr", "wiring-scope", "Guard solo-team BP symmetry"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {


### PR DESCRIPTION
Phase C3: remove legacy 'Guard solo.json <-> team.json symmetry' from solo/team policy configs now that only 'Guard solo-team BP symmetry' is required.