### PR TITLE
ci: pin Augment + gitStream actions to commit SHAs

### DIFF
--- a/.github/workflows/augment-agent.yml
+++ b/.github/workflows/augment-agent.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Augment PR review
-        uses: augmentcode/review-pr@v0
+        uses: augmentcode/review-pr@e24b40c86b325aecbbf8085e34270745589aaadc # v0
         env:
           AUGMENT_SESSION_AUTH: ${{ secrets.AUGMENT_SESSION_AUTH }}

--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -47,7 +47,7 @@ jobs:
           echo '[${{ fromJSON(fromJSON(inputs.client_payload)).repo }}#${{ fromJSON(fromJSON(inputs.client_payload)).prContext.number }}](${{ fromJSON(fromJSON(inputs.client_payload)).prContext.url }}) - `${{ fromJSON(fromJSON(inputs.client_payload)).branch }}` by ${{ fromJSON(fromJSON(inputs.client_payload)).prContext.author }}' >> $GITHUB_STEP_SUMMARY
 
       - name: gitStream repo agent
-        uses: linear-b/gitstream-github-action@2.0.221
+        uses: linear-b/gitstream-github-action@d5311d4fa5af97c02416d6a2a4a7bdf06dfca314 # 2.0.221
         id: rules-engine
         with:
           full_repository: ${{ github.event.inputs.full_repository }}


### PR DESCRIPTION
Pins Augment + gitStream GitHub Actions to immutable commit SHAs (keeps tags as comments) for supply-chain hardening.