### PR TITLE
ci: group GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+    labels:
+      - "dependencies"
+      - "ci"
+
+    groups:
+      github-actions-weekly:
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
Groups all GitHub Actions updates into one weekly PR and labels PRs dependencies+ci.