### PR TITLE
ci: add token health fields to drift summary

### DIFF
--- a/.github/branch-protection/bp_drift_summary.schema.json
+++ b/.github/branch-protection/bp_drift_summary.schema.json
@@ -79,6 +79,19 @@
     "token_admin_read_ok": {
       "type": "boolean",
       "description": "True iff token allowed reading branch protection required_status_checks (Administration: Read)."
+    },
+    "token_checked_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp for when the token capability checks were performed (non-identifying)."
+    },
+    "token_scope_repo": {
+      "type": "boolean",
+      "description": "True iff the workflow successfully used the token against repo-scoped endpoints (non-identifying)."
+    },
+    "token_permission_admin_read": {
+      "type": "boolean",
+      "description": "True iff the token appears to have Administration: Read for this repo (alias of token_admin_read_ok; non-identifying)."
     }
   }
 }

--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -85,6 +85,7 @@ jobs:
             const summary = {
               schema_version: "bp_drift_summary.v1",
               generated_at: new Date().toISOString(),
+              token_checked_at: new Date().toISOString(),
               repo,
               branch,
               mode: "solo",
@@ -94,7 +95,9 @@ jobs:
               extra_contexts: extra,
               ok: actualRes.ok && missing.length === 0 && extra.length === 0,
               token_present,
-              token_admin_read_ok: actualRes.token_admin_read_ok
+              token_admin_read_ok: actualRes.token_admin_read_ok,
+              token_scope_repo: actualRes.ok,
+              token_permission_admin_read: actualRes.token_admin_read_ok
             };
 
             fs.writeFileSync("bp_drift_summary.json", JSON.stringify(summary, null, 2));
@@ -107,6 +110,7 @@ jobs:
             const fallback = {
               schema_version: "bp_drift_summary.v1",
               generated_at: new Date().toISOString(),
+              token_checked_at: new Date().toISOString(),
               repo,
               branch,
               mode: "solo",
@@ -116,7 +120,9 @@ jobs:
               extra_contexts: [],
               ok: false,
               token_present,
-              token_admin_read_ok: false
+              token_admin_read_ok: false,
+              token_scope_repo: false,
+              token_permission_admin_read: false
             };
             fs.writeFileSync("bp_drift_summary.json", JSON.stringify(fallback, null, 2));
             const out = process.env.GITHUB_OUTPUT;

--- a/scripts/verify/post-merge-ritual.ps1
+++ b/scripts/verify/post-merge-ritual.ps1
@@ -77,6 +77,14 @@ TryCmd {
 
   Write-Host ("ok: " + $s.ok) -ForegroundColor Cyan
   Write-Host ("token_present: " + $s.token_present + " | token_admin_read_ok: " + $s.token_admin_read_ok) -ForegroundColor Cyan
+  if ($null -ne $s.token_checked_at) {
+    Write-Host ("token_checked_at: " + $s.token_checked_at) -ForegroundColor Cyan
+  }
+  if ($null -ne $s.token_scope_repo -or $null -ne $s.token_permission_admin_read) {
+    $scopeRepo = if ($null -ne $s.token_scope_repo) { $s.token_scope_repo } else { "(n/a)" }
+    $adminRead = if ($null -ne $s.token_permission_admin_read) { $s.token_permission_admin_read } else { "(n/a)" }
+    Write-Host ("token_scope_repo: " + $scopeRepo + " | token_permission_admin_read: " + $adminRead) -ForegroundColor Cyan
+  }
 
   Write-Host "`nExpected contexts:" -ForegroundColor Gray
   $s.expected_contexts | ForEach-Object { Write-Host "  - $_" }


### PR DESCRIPTION
Adds non-identifying token health proof fields to the branch-protection drift summary artifact (timestamp + booleans), updates the JSON Schema accordingly, and prints them in the post-merge ritual when present.