### PR TITLE
ci: add schema_version to bp drift summary exhibit

### DIFF
--- a/.github/branch-protection/bp_drift_summary.schema.json
+++ b/.github/branch-protection/bp_drift_summary.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.invalid/schemas/bp_drift_summary.v1.schema.json",
+  "$id": "https://example.invalid/schemas/bp_drift_summary.1.1.schema.json",
   "title": "Branch Protection Drift Summary",
-  "description": "Machine-readable summary emitted by verify-branch-protection workflow. Captures expected vs actual required status-check contexts, drift, and token/permission booleans.",
+  "description": "Machine-readable summary emitted by verify-branch-protection workflow. Captures expected vs actual required status-check contexts, drift, and token/permission booleans. schema_version is pinned for evidence packs.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -22,7 +22,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "const": "bp_drift_summary.v1"
+      "const": "1.1",
+      "description": "Pinned schema version for bp_drift_summary.json exhibits."
     },
     "generated_at": {
       "type": "string",

--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -83,7 +83,7 @@ jobs:
             const extra = diff(actual, expected);
 
             const summary = {
-              schema_version: "bp_drift_summary.v1",
+              schema_version: "1.1",
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,
@@ -108,7 +108,7 @@ jobs:
             fs.appendFileSync(out, `token_admin_read_ok=${summary.token_admin_read_ok}\n`);
           })().catch(err => {
             const fallback = {
-              schema_version: "bp_drift_summary.v1",
+              schema_version: "1.1",
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,

--- a/scripts/verify/post-merge-ritual.ps1
+++ b/scripts/verify/post-merge-ritual.ps1
@@ -75,6 +75,15 @@ TryCmd {
 
   $s = Get-Content $found.FullName -Raw | ConvertFrom-Json
 
+  if ($null -ne $s.schema_version) {
+    Write-Host ("schema_version: " + $s.schema_version) -ForegroundColor Cyan
+    if ($s.schema_version -ne "1.1") {
+      Write-Host ("WARNING: unexpected schema_version (expected 1.1)") -ForegroundColor Yellow
+    }
+  } else {
+    Write-Host "schema_version: (missing)" -ForegroundColor Yellow
+  }
+
   Write-Host ("ok: " + $s.ok) -ForegroundColor Cyan
   Write-Host ("token_present: " + $s.token_present + " | token_admin_read_ok: " + $s.token_admin_read_ok) -ForegroundColor Cyan
   if ($null -ne $s.token_checked_at) {


### PR DESCRIPTION
Adds schema_version: '1.1' to bp_drift_summary.json and pins it in the JSON Schema for long-term evidence packs. Ritual prints it and warns (without failing) if missing/mismatched.