### PR TITLE
Polish: ritual prints meaning for token probe status

### DIFF
--- a/.github/branch-protection/bp_drift_summary.schema.json
+++ b/.github/branch-protection/bp_drift_summary.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://example.invalid/schemas/bp_drift_summary.1.1.schema.json",
   "title": "Branch Protection Drift Summary",
   "description": "Machine-readable summary emitted by verify-branch-protection workflow. Captures expected vs actual required status-check contexts, drift, and token/permission booleans. schema_version is pinned for evidence packs.",
+  "$comment": "Schema upgrade discipline: bump schema_version only when required fields change or when the meaning/semantics of existing fields change. Adding optional fields (like extra non-sensitive diagnostics) should not require a schema_version bump.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -87,6 +87,7 @@ jobs:
             const extra = diff(actual, expected);
 
             const summary = {
+              // Schema upgrade discipline: bump only when required fields or semantics change.
               schema_version: "1.1",
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),

--- a/scripts/verify/post-merge-ritual.ps1
+++ b/scripts/verify/post-merge-ritual.ps1
@@ -87,7 +87,16 @@ TryCmd {
   Write-Host ("ok: " + $s.ok) -ForegroundColor Cyan
   Write-Host ("token_present: " + $s.token_present + " | token_admin_read_ok: " + $s.token_admin_read_ok) -ForegroundColor Cyan
   if ($s.PSObject.Properties.Name -contains 'token_admin_read_http_status') {
-    Write-Host ("token_admin_read_http_status: " + $s.token_admin_read_http_status) -ForegroundColor Cyan
+    $code = [int]$s.token_admin_read_http_status
+    $meaning = switch ($code) {
+      200 { "OK" }
+      401 { "bad token/header" }
+      403 { "under-scoped" }
+      404 { "no admin or wrong endpoint" }
+      0 { "network/tool failure" }
+      default { "(unknown)" }
+    }
+    Write-Host ("token_admin_read_http_status: " + $code + " (" + $meaning + ")") -ForegroundColor Cyan
   }
   if ($null -ne $s.token_checked_at) {
     Write-Host ("token_checked_at: " + $s.token_checked_at) -ForegroundColor Cyan


### PR DESCRIPTION
Optional polish:\n\n- Ritual prints token_admin_read_http_status with a human meaning (200 OK / 401 bad token/header / 403 under-scoped / 404 no admin or wrong endpoint / 0 network/tool failure).\n- Adds schema upgrade discipline note (JSON Schema  + workflow comment) to prevent casual schema_version bumps.\n\nNo secrets, no response bodies, artifact-first.