### PR TITLE
Hardening: artifact self-points to schema

### DIFF
--- a/.github/branch-protection/bp_drift_summary.schema.json
+++ b/.github/branch-protection/bp_drift_summary.schema.json
@@ -26,6 +26,11 @@
       "const": "1.1",
       "description": "Pinned schema version for bp_drift_summary.json exhibits."
     },
+    "schema_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repo-relative path to the JSON Schema that validates this exhibit (non-identifying)."
+    },
     "generated_at": {
       "type": "string",
       "format": "date-time",

--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -89,6 +89,7 @@ jobs:
             const summary = {
               // Schema upgrade discipline: bump only when required fields or semantics change.
               schema_version: "1.1",
+              schema_path: ".github/branch-protection/bp_drift_summary.schema.json",
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,
@@ -116,6 +117,7 @@ jobs:
           })().catch(err => {
             const fallback = {
               schema_version: "1.1",
+              schema_path: ".github/branch-protection/bp_drift_summary.schema.json",
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,

--- a/scripts/verify/post-merge-ritual.ps1
+++ b/scripts/verify/post-merge-ritual.ps1
@@ -80,6 +80,9 @@ TryCmd {
     if ($s.schema_version -ne "1.1") {
       Write-Host ("WARNING: unexpected schema_version (expected 1.1)") -ForegroundColor Yellow
     }
+    if ($s.PSObject.Properties.Name -contains 'schema_path') {
+      Write-Host ("schema_path: " + $s.schema_path) -ForegroundColor Cyan
+    }
   } else {
     Write-Host "schema_version: (missing)" -ForegroundColor Yellow
   }


### PR DESCRIPTION
Optional hardening: add non-sensitive schema_path to p_drift_summary.json so evidence packs can self-locate the validating JSON Schema.\n\n- Adds schema_path: .github/branch-protection/bp_drift_summary.schema.json to the exhibit (success + fallback).\n- Extends schema to allow it (still schema_version 1.1; optional field).\n- Ritual prints it when present.\n\nNo secrets, no URLs required, artifact-first.