### PR TITLE
Add schema_url to drift exhibit

### DIFF
--- a/.github/branch-protection/bp_drift_summary.schema.json
+++ b/.github/branch-protection/bp_drift_summary.schema.json
@@ -31,6 +31,12 @@
       "minLength": 1,
       "description": "Repo-relative path to the JSON Schema that validates this exhibit (non-identifying)."
     },
+    "schema_url": {
+      "type": "string",
+      "format": "uri",
+      "minLength": 1,
+      "description": "SHA-pinned URL to the JSON Schema for this exhibit (built from GITHUB_SERVER_URL/GITHUB_SHA; non-identifying)."
+    },
     "generated_at": {
       "type": "string",
       "format": "date-time",

--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -40,6 +40,8 @@ jobs:
           const branch = process.env.BRANCH || "master";
           const token = process.env.BP_TOKEN || "";
           const githubApiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+          const githubServerUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+          const githubSha = process.env.GITHUB_SHA || "";
 
           const token_present = token.length > 0;
 
@@ -86,10 +88,16 @@ jobs:
             const missing = diff(expected, actual);
             const extra = diff(actual, expected);
 
+            const schemaPath = ".github/branch-protection/bp_drift_summary.schema.json";
+            const schemaUrl = githubSha
+              ? `${githubServerUrl}/${repo}/raw/${githubSha}/${schemaPath}`
+              : undefined;
+
             const summary = {
               // Schema upgrade discipline: bump only when required fields or semantics change.
               schema_version: "1.1",
-              schema_path: ".github/branch-protection/bp_drift_summary.schema.json",
+              schema_path: schemaPath,
+              schema_url: schemaUrl,
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,
@@ -118,6 +126,9 @@ jobs:
             const fallback = {
               schema_version: "1.1",
               schema_path: ".github/branch-protection/bp_drift_summary.schema.json",
+              schema_url: githubSha
+                ? `${githubServerUrl}/${repo}/raw/${githubSha}/.github/branch-protection/bp_drift_summary.schema.json`
+                : undefined,
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,

--- a/scripts/verify/post-merge-ritual.ps1
+++ b/scripts/verify/post-merge-ritual.ps1
@@ -83,6 +83,9 @@ TryCmd {
     if ($s.PSObject.Properties.Name -contains 'schema_path') {
       Write-Host ("schema_path: " + $s.schema_path) -ForegroundColor Cyan
     }
+    if ($s.PSObject.Properties.Name -contains 'schema_url') {
+      Write-Host ("schema_url: " + $s.schema_url) -ForegroundColor Cyan
+    }
   } else {
     Write-Host "schema_version: (missing)" -ForegroundColor Yellow
   }


### PR DESCRIPTION
Adds optional schema_url to p_drift_summary.json, pinned to the run commit SHA (via GITHUB_SHA).

- Workflow now emits schema_url alongside schema_path
- Schema allows schema_url as optional (no schema_version bump)
- Ritual prints schema_url when present