### PR TITLE
Add schema_sha256 to drift exhibit

### DIFF
--- a/.github/branch-protection/bp_drift_summary.schema.json
+++ b/.github/branch-protection/bp_drift_summary.schema.json
@@ -37,6 +37,11 @@
       "minLength": 1,
       "description": "SHA-pinned URL to the JSON Schema for this exhibit (built from GITHUB_SERVER_URL/GITHUB_SHA; non-identifying)."
     },
+    "schema_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "SHA-256 hex digest of the schema file contents at schema_path (non-identifying, tamper-evident metadata)."
+    },
     "generated_at": {
       "type": "string",
       "format": "date-time",

--- a/.github/workflows/verify-branch-protection.yml
+++ b/.github/workflows/verify-branch-protection.yml
@@ -34,6 +34,7 @@ jobs:
           BP_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
         run: |
           node <<'NODE'
+          const crypto = require("crypto");
           const fs = require("fs");
 
           const repo = process.env.REPO;
@@ -42,6 +43,33 @@ jobs:
           const githubApiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
           const githubServerUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
           const githubSha = process.env.GITHUB_SHA || "";
+
+          const schemaPath = ".github/branch-protection/bp_drift_summary.schema.json";
+          const rawBase = (() => {
+            try {
+              const host = new URL(githubServerUrl).hostname;
+              if (host === "github.com") return "https://raw.githubusercontent.com";
+            } catch (_) {}
+            return githubServerUrl;
+          })();
+
+          const schemaUrl = (() => {
+            if (!githubSha) return undefined;
+            // Prefer raw-content host (not web UI); fall back to GHES-compatible /raw/ path.
+            if (rawBase === "https://raw.githubusercontent.com") {
+              return `${rawBase}/${repo}/${githubSha}/${schemaPath}`;
+            }
+            return `${rawBase}/${repo}/raw/${githubSha}/${schemaPath}`;
+          })();
+
+          const schemaSha256 = (() => {
+            try {
+              const bytes = fs.readFileSync(schemaPath);
+              return crypto.createHash("sha256").update(bytes).digest("hex");
+            } catch (_) {
+              return undefined;
+            }
+          })();
 
           const token_present = token.length > 0;
 
@@ -88,16 +116,12 @@ jobs:
             const missing = diff(expected, actual);
             const extra = diff(actual, expected);
 
-            const schemaPath = ".github/branch-protection/bp_drift_summary.schema.json";
-            const schemaUrl = githubSha
-              ? `${githubServerUrl}/${repo}/raw/${githubSha}/${schemaPath}`
-              : undefined;
-
             const summary = {
               // Schema upgrade discipline: bump only when required fields or semantics change.
               schema_version: "1.1",
               schema_path: schemaPath,
               schema_url: schemaUrl,
+              schema_sha256: schemaSha256,
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,
@@ -125,10 +149,9 @@ jobs:
           })().catch(err => {
             const fallback = {
               schema_version: "1.1",
-              schema_path: ".github/branch-protection/bp_drift_summary.schema.json",
-              schema_url: githubSha
-                ? `${githubServerUrl}/${repo}/raw/${githubSha}/.github/branch-protection/bp_drift_summary.schema.json`
-                : undefined,
+              schema_path: schemaPath,
+              schema_url: schemaUrl,
+              schema_sha256: schemaSha256,
               generated_at: new Date().toISOString(),
               token_checked_at: new Date().toISOString(),
               repo,

--- a/scripts/verify/post-merge-ritual.ps1
+++ b/scripts/verify/post-merge-ritual.ps1
@@ -81,10 +81,13 @@ TryCmd {
       Write-Host ("WARNING: unexpected schema_version (expected 1.1)") -ForegroundColor Yellow
     }
     if ($s.PSObject.Properties.Name -contains 'schema_path') {
-      Write-Host ("schema_path: " + $s.schema_path) -ForegroundColor Cyan
+      Write-Host ("schema_path (repo-relative): " + $s.schema_path) -ForegroundColor Cyan
     }
     if ($s.PSObject.Properties.Name -contains 'schema_url') {
-      Write-Host ("schema_url: " + $s.schema_url) -ForegroundColor Cyan
+      Write-Host ("schema_url (sha-pinned): " + $s.schema_url) -ForegroundColor Cyan
+    }
+    if ($s.PSObject.Properties.Name -contains 'schema_sha256') {
+      Write-Host ("schema_sha256: " + $s.schema_sha256) -ForegroundColor Cyan
     }
   } else {
     Write-Host "schema_version: (missing)" -ForegroundColor Yellow


### PR DESCRIPTION
Adds optional schema_sha256 (SHA-256 hex digest of the schema file contents) to p_drift_summary.json.

- Computed in-workflow from schema_path content (public repo file)
- Schema allows schema_sha256 as optional (no schema_version bump)
- Ritual prints schema pointers with clearer labels and prints schema_sha256 when present
- Tightens schema_url to a raw-content URL with exact commit SHA