### PR TITLE
fix(reliability): guard ai memory extraction parsing and redact logs

### DIFF
--- a/artifacts/swarm/daily/2026-04-12/04_selected_work.json
+++ b/artifacts/swarm/daily/2026-04-12/04_selected_work.json
@@ -1,0 +1,12 @@
+{
+  "date": "2026-04-12",
+  "unit": "unit_01",
+  "selected_issue": "AI memory extraction parse guards + log redaction boundary",
+  "priority_target_tags": [
+    "malformed input guards",
+    "redaction boundaries in logs/errors",
+    "silent failure patterns"
+  ],
+  "selection_reason": "Single-file reliability weakness with direct evidence in production code and a practical regression-test seam.",
+  "status": "patched_on_branch_pending_ci_status"
+}

--- a/artifacts/swarm/daily/2026-04-12/05_changed_files.json
+++ b/artifacts/swarm/daily/2026-04-12/05_changed_files.json
@@ -1,0 +1,39 @@
+{
+  "files_changed": [
+    {
+      "path": "webapp/server/ai-memory-router.ts",
+      "change_type": "modified",
+      "why": "Add content coercion, schema validation, and redacted parse/error logging for AI memory extraction."
+    },
+    {
+      "path": "webapp/server/ai-memory-router.test.ts",
+      "change_type": "added",
+      "why": "Regression coverage for fenced JSON parsing, text-array coercion, invalid-shape rejection, and non-text multimodal payload handling."
+    },
+    {
+      "path": "artifacts/swarm/daily/2026-04-12/unit_01.md",
+      "change_type": "added",
+      "why": "Required change proposal and execution note."
+    },
+    {
+      "path": "artifacts/swarm/daily/2026-04-12/04_selected_work.json",
+      "change_type": "added",
+      "why": "Required selected-work record."
+    },
+    {
+      "path": "artifacts/swarm/daily/2026-04-12/05_changed_files.json",
+      "change_type": "added",
+      "why": "Required changed-files record."
+    },
+    {
+      "path": "artifacts/swarm/daily/2026-04-12/06_verification_results.json",
+      "change_type": "added",
+      "why": "Required verification record."
+    },
+    {
+      "path": "artifacts/swarm/daily/2026-04-12/07_risk_register.json",
+      "change_type": "added",
+      "why": "Required residual-risk record."
+    }
+  ]
+}

--- a/artifacts/swarm/daily/2026-04-12/06_verification_results.json
+++ b/artifacts/swarm/daily/2026-04-12/06_verification_results.json
@@ -1,0 +1,25 @@
+{
+  "verification": {
+    "static_review": {
+      "status": "passed",
+      "checks": [
+        "ai-memory-router now coerces non-string LLM content before parsing",
+        "memory extraction output is schema-validated before inserts",
+        "parse-failure logging uses metadata only, not raw payloads",
+        "targeted unit test file added"
+      ]
+    },
+    "diff_scope_review": {
+      "status": "pending_compare",
+      "notes": "Use compare_commits against master to confirm final narrowed file list."
+    },
+    "ci_status": {
+      "status": "pending_remote_status",
+      "notes": "No local runner was available in the workspace; GitHub commit status must be checked after push-triggered workflows report."
+    }
+  },
+  "do_not_claim_fixed_until": [
+    "compare_commits confirms intended scope",
+    "GitHub combined status returns success or there is an explicit reason no checks ran"
+  ]
+}

--- a/artifacts/swarm/daily/2026-04-12/07_risk_register.json
+++ b/artifacts/swarm/daily/2026-04-12/07_risk_register.json
@@ -1,0 +1,22 @@
+{
+  "residual_risks": [
+    {
+      "id": "R-UNIT-01-001",
+      "title": "Router-level regression tests may not execute if repository test selection excludes the new file",
+      "severity": "medium",
+      "mitigation": "Check remote status and, if needed, wire the new test file into the current test invocation strategy."
+    },
+    {
+      "id": "R-UNIT-01-002",
+      "title": "Provider may return valid JSON in non-text multimodal parts that are intentionally ignored by the new coercion logic",
+      "severity": "low",
+      "mitigation": "Prefer explicit text output for memory extraction prompts; extend coercion only if a provider is confirmed to embed structured output elsewhere."
+    },
+    {
+      "id": "R-UNIT-01-003",
+      "title": "No in-workspace local runner was available for execution verification",
+      "severity": "medium",
+      "mitigation": "Rely on GitHub combined status and follow up on any failed or missing checks before merge."
+    }
+  ]
+}

--- a/artifacts/swarm/daily/2026-04-12/unit_01.md
+++ b/artifacts/swarm/daily/2026-04-12/unit_01.md
@@ -1,0 +1,22 @@
+CHANGE_PROPOSAL
+- claim_being_verified_or_corrected: AI memory extraction should tolerate non-string or malformed LLM payloads without leaking raw payload content into logs.
+- evidence:
+  - webapp/server/ai-memory-router.ts directly calls .match() / JSON.parse() on response.choices[0]?.message?.content even though webapp/server/_core/llm.ts allows that content to be a string or an array of multimodal content parts.
+  - On parse failure, the current code logs raw content.
+- files_likely_affected:
+  - webapp/server/ai-memory-router.ts
+  - webapp/server/ai-memory-router.test.ts
+- change_reason: Add malformed-input guards and redacted failure logging around one brittle parsing path with minimal churn.
+- verification_plan:
+  - add a targeted regression test for fenced JSON, text-part arrays, invalid-shape payloads, and non-text multimodal payloads
+  - compare branch diff against master to confirm narrow scope
+  - inspect commit status checks exposed by GitHub
+- rollback_plan: revert the reliability patch commits on fix/reliability-ai-memory-parse-guards
+
+Selected issue
+- AI memory extraction parse guards + log redaction boundary
+
+Expected reliability impact
+- Prevents .match() / JSON.parse() misuse on array-based LLM content
+- Converts malformed or non-text model output into a controlled { success: false, extracted: 0 } result
+- Stops raw payload spill in parse-failure logs

--- a/webapp/server/ai-memory-router.test.ts
+++ b/webapp/server/ai-memory-router.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceMemoryExtractionContent,
+  parseExtractedMemories,
+  summarizeMemoryExtractionContent,
+} from "./ai-memory-router";
+
+describe("ai-memory extraction guards", () => {
+  it("parses fenced JSON array content", () => {
+    const parsed = parseExtractedMemories(
+      '```json\n[{"category":"general_context","key":"role","value":"pro se litigant","importance":4}]\n```'
+    );
+
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.memories).toHaveLength(1);
+      expect(parsed.memories[0]).toMatchObject({
+        category: "general_context",
+        key: "role",
+        value: "pro se litigant",
+        importance: 4,
+      });
+    }
+  });
+
+  it("coerces text-part arrays into a single string", () => {
+    const content = coerceMemoryExtractionContent([
+      { type: "text", text: '[{"category":"case_fact",' },
+      { type: "text", text: '"key":"incident_date","value":"Jan 1","importance":5}]' },
+    ]);
+
+    expect(content).toBe(
+      '[{"category":"case_fact",\n"key":"incident_date","value":"Jan 1","importance":5}]'
+    );
+  });
+
+  it("returns invalid_shape for schema-invalid payloads with safe log context", () => {
+    const parsed = parseExtractedMemories('[{"category":"general_context","value":"missing key"}]');
+
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.reason).toBe("invalid_shape");
+      expect(parsed.logContext).toEqual({
+        contentLength: '[{"category":"general_context","value":"missing key"}]'.length,
+        hasJsonArray: true,
+        startsWithCodeFence: false,
+      });
+    }
+  });
+
+  it("returns missing_content for non-text multimodal payloads", () => {
+    const content = coerceMemoryExtractionContent([
+      {
+        type: "image_url",
+        image_url: {
+          url: "https://example.com/proof.png",
+        },
+      },
+    ]);
+
+    expect(content).toBeNull();
+
+    const parsed = parseExtractedMemories(content);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.reason).toBe("missing_content");
+      expect(parsed.logContext).toEqual(summarizeMemoryExtractionContent(null));
+    }
+  });
+});

--- a/webapp/server/ai-memory-router.ts
+++ b/webapp/server/ai-memory-router.ts
@@ -4,16 +4,117 @@ import { getDb } from "./db";
 import { aiMemory } from "../drizzle/schema-ai-memory";
 import { eq, and, desc } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { invokeLLM } from "./_core/llm";
+import { invokeLLM, type InvokeResult } from "./_core/llm";
+
+const memoryCategorySchema = z.enum([
+  "user_preference",
+  "case_fact",
+  "legal_strategy",
+  "general_context",
+]);
+
+const extractedMemoryArraySchema = z.array(
+  z.object({
+    category: memoryCategorySchema,
+    key: z.string().min(1),
+    value: z.string().min(1),
+    importance: z.number().int().min(1).max(5).optional(),
+  })
+);
+
+type ExtractedMemory = z.infer<typeof extractedMemoryArraySchema>[number];
+type LlmMessageContent = InvokeResult["choices"][number]["message"]["content"];
+
+type MemoryParseResult =
+  | {
+      ok: true;
+      memories: ExtractedMemory[];
+    }
+  | {
+      ok: false;
+      reason: "missing_content" | "invalid_json" | "invalid_shape";
+      logContext: {
+        contentLength: number;
+        hasJsonArray: boolean;
+        startsWithCodeFence: boolean;
+      };
+    };
+
+export function coerceMemoryExtractionContent(
+  content: LlmMessageContent | undefined
+): string | null {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const textContent = content
+    .filter((part): part is Extract<LlmMessageContent[number], { type: "text" }> => part.type === "text")
+    .map(part => part.text.trim())
+    .filter(Boolean);
+
+  return textContent.length > 0 ? textContent.join("\n") : null;
+}
+
+export function summarizeMemoryExtractionContent(content: string | null) {
+  return {
+    contentLength: content?.length ?? 0,
+    hasJsonArray: typeof content === "string" && /\[[\s\S]*\]/.test(content),
+    startsWithCodeFence: typeof content === "string" && content.trimStart().startsWith("```"),
+  };
+}
+
+export function parseExtractedMemories(content: string | null): MemoryParseResult {
+  const logContext = summarizeMemoryExtractionContent(content);
+
+  if (!content) {
+    return {
+      ok: false,
+      reason: "missing_content",
+      logContext,
+    };
+  }
+
+  const candidate = content.match(/\[[\s\S]*\]/)?.[0] ?? content;
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(candidate);
+  } catch {
+    return {
+      ok: false,
+      reason: "invalid_json",
+      logContext,
+    };
+  }
+
+  const parsed = extractedMemoryArraySchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: "invalid_shape",
+      logContext,
+    };
+  }
+
+  return {
+    ok: true,
+    memories: parsed.data,
+  };
+}
 
 export const aiMemoryRouter = router({
-  // List all memories for the current user
   list: protectedProcedure
     .input(
-      z.object({
-        caseId: z.number().optional(),
-        category: z.enum(["user_preference", "case_fact", "legal_strategy", "general_context"]).optional(),
-      }).optional()
+      z
+        .object({
+          caseId: z.number().optional(),
+          category: memoryCategorySchema.optional(),
+        })
+        .optional()
     )
     .query(async ({ ctx, input }) => {
       const db = await getDb();
@@ -21,12 +122,12 @@ export const aiMemoryRouter = router({
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
       }
 
-      let conditions = [eq(aiMemory.userId, ctx.user.id)];
-      
+      const conditions = [eq(aiMemory.userId, ctx.user.id)];
+
       if (input?.caseId) {
         conditions.push(eq(aiMemory.caseId, input.caseId));
       }
-      
+
       if (input?.category) {
         conditions.push(eq(aiMemory.category, input.category));
       }
@@ -38,12 +139,11 @@ export const aiMemoryRouter = router({
         .orderBy(desc(aiMemory.importance), desc(aiMemory.updatedAt));
     }),
 
-  // Add a new memory manually
   add: protectedProcedure
     .input(
       z.object({
         caseId: z.number().optional(),
-        category: z.enum(["user_preference", "case_fact", "legal_strategy", "general_context"]),
+        category: memoryCategorySchema,
         key: z.string().min(1),
         value: z.string().min(1),
         importance: z.number().min(1).max(5).default(3),
@@ -68,12 +168,11 @@ export const aiMemoryRouter = router({
       return { success: true, id: result.insertId };
     }),
 
-  // Update an existing memory
   update: protectedProcedure
     .input(
       z.object({
         id: z.number(),
-        category: z.enum(["user_preference", "case_fact", "legal_strategy", "general_context"]).optional(),
+        category: memoryCategorySchema.optional(),
         key: z.string().optional(),
         value: z.string().optional(),
         importance: z.number().min(1).max(5).optional(),
@@ -85,7 +184,6 @@ export const aiMemoryRouter = router({
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
       }
 
-      // Verify ownership
       const [memory] = await db
         .select()
         .from(aiMemory)
@@ -95,7 +193,7 @@ export const aiMemoryRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
       }
 
-      const updateData: any = { updatedAt: new Date() };
+      const updateData: Record<string, unknown> = { updatedAt: new Date() };
       if (input.category) updateData.category = input.category;
       if (input.key) updateData.key = input.key;
       if (input.value) updateData.value = input.value;
@@ -109,7 +207,6 @@ export const aiMemoryRouter = router({
       return { success: true };
     }),
 
-  // Delete a memory
   delete: protectedProcedure
     .input(z.object({ id: z.number() }))
     .mutation(async ({ ctx, input }) => {
@@ -118,7 +215,6 @@ export const aiMemoryRouter = router({
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
       }
 
-      // Verify ownership and delete
       await db
         .delete(aiMemory)
         .where(and(eq(aiMemory.id, input.id), eq(aiMemory.userId, ctx.user.id)));
@@ -126,7 +222,6 @@ export const aiMemoryRouter = router({
       return { success: true };
     }),
 
-  // Extract memory from chat message using LLM
   extractFromMessage: protectedProcedure
     .input(
       z.object({
@@ -165,51 +260,45 @@ Return a JSON array of objects with the following schema:
         const response = await invokeLLM({
           messages: [
             { role: "system", content: systemPrompt },
-            { role: "user", content: input.message }
-          ]
+            { role: "user", content: input.message },
+          ],
         });
 
-        const content = response.choices[0]?.message?.content || "[]";
-        
-        // Try to parse the JSON response
-        let extractedMemories = [];
-        try {
-          // Find JSON array in the response (in case the LLM added markdown formatting)
-          const jsonMatch = content.match(/\[[\s\S]*\]/);
-          if (jsonMatch) {
-            extractedMemories = JSON.parse(jsonMatch[0]);
-          } else {
-            extractedMemories = JSON.parse(content);
-          }
-        } catch (e) {
-          console.error("Failed to parse memory extraction JSON:", content);
+        const parsed = parseExtractedMemories(
+          coerceMemoryExtractionContent(response.choices[0]?.message?.content)
+        );
+
+        if (!parsed.ok) {
+          console.error("Failed to parse memory extraction payload", {
+            reason: parsed.reason,
+            ...parsed.logContext,
+          });
           return { success: false, extracted: 0 };
         }
 
-        if (!Array.isArray(extractedMemories) || extractedMemories.length === 0) {
+        if (parsed.memories.length === 0) {
           return { success: true, extracted: 0 };
         }
 
-        // Insert the extracted memories
         let insertedCount = 0;
-        for (const memory of extractedMemories) {
-          if (memory.category && memory.key && memory.value) {
-            await db.insert(aiMemory).values({
-              userId: ctx.user.id,
-              caseId: input.caseId,
-              category: memory.category,
-              key: memory.key,
-              value: memory.value,
-              importance: memory.importance || 3,
-              source: "chat_extraction",
-            });
-            insertedCount++;
-          }
+        for (const memory of parsed.memories) {
+          await db.insert(aiMemory).values({
+            userId: ctx.user.id,
+            caseId: input.caseId,
+            category: memory.category,
+            key: memory.key,
+            value: memory.value,
+            importance: memory.importance ?? 3,
+            source: "chat_extraction",
+          });
+          insertedCount++;
         }
 
         return { success: true, extracted: insertedCount };
       } catch (error) {
-        console.error("Memory extraction error:", error);
+        console.error("Memory extraction error", {
+          errorType: error instanceof Error ? error.name : typeof error,
+        });
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to extract memory",


### PR DESCRIPTION
This PR applies a surgical reliability patch for AI memory extraction.

What changed:
- Coerce LLM message content safely before parsing
- Handle array-based text content instead of assuming plain strings
- Validate extracted memories with Zod before insert
- Log metadata-only parse failure context instead of raw payloads
- Add targeted regression coverage for malformed and multimodal payloads

Requested verification:
- full CI run on pull_request
- confirm pnpm test, type/schema gates, and integration-local-mock results
