### PR TITLE
chore(workspace): add root workspaces field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "agent-mode-engine",
   "private": true,
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
   "type": "module",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- add root `workspaces` to `package.json`
- align root package metadata with existing `pnpm-workspace.yaml`
- keep scope to one file and one coherent workspace config change

## Evidence
- `pnpm-workspace.yaml` already defines `packages/*` and `apps/*`
- this branch adds the matching root `workspaces` field only
- compare vs `master`: 1 file changed, `package.json`, +4 lines

## Verification
- GitHub compare shows branch is ahead by 1 commit
- changed files: `package.json` only
- local build/typecheck was not run from this environment because the repo working tree is not mounted here

## Risk
- low
- possible tooling behavior differences if any workflow reads only root `package.json` workspaces and ignored `pnpm-workspace.yaml` before; this change makes that configuration explicit rather than changing package layout
