### PR TITLE
fix(api): harden list query parsing and normalize aliases

### DIFF
--- a/apps/api/src/models/beneficiary.schema.ts
+++ b/apps/api/src/models/beneficiary.schema.ts
@@ -1,5 +1,73 @@
 import { z } from 'zod';
 
+const normalizeQueryValue = (value: unknown) => {
+  const normalized = Array.isArray(value) ? value[0] : value;
+  return typeof normalized === 'string' ? normalized.trim() : normalized;
+};
+
+const positiveIntQueryParam = (fieldName: string, defaultValue: number, max?: number) => {
+  const baseSchema = z.number().int(`${fieldName} must be an integer`).min(1, `${fieldName} must be at least 1`);
+  const boundedSchema = typeof max === 'number'
+    ? baseSchema.max(max, `${fieldName} must be at most ${max}`)
+    : baseSchema;
+
+  return z.preprocess((value) => {
+    const normalized = normalizeQueryValue(value);
+
+    if (normalized === undefined || normalized === null || normalized === '') {
+      return defaultValue;
+    }
+
+    if (typeof normalized === 'number' && Number.isInteger(normalized)) {
+      return normalized;
+    }
+
+    if (typeof normalized === 'string' && /^\d+$/.test(normalized)) {
+      return Number.parseInt(normalized, 10);
+    }
+
+    return Number.NaN;
+  }, boundedSchema);
+};
+
+const sortOrderQueryParam = z.preprocess((value) => {
+  const normalized = normalizeQueryValue(value);
+  return typeof normalized === 'string' ? normalized.toLowerCase() : normalized;
+}, z.enum(['asc', 'desc']).optional());
+
+const beneficiarySortByQueryParam = z.preprocess(normalizeQueryValue, z.enum([
+  'first_name',
+  'firstName',
+  'last_name',
+  'lastName',
+  'email',
+  'created_at',
+  'createdAt',
+]).optional());
+
+const searchQueryParam = z.preprocess((value) => {
+  const normalized = normalizeQueryValue(value);
+  return normalized === '' ? undefined : normalized;
+}, z.string().optional());
+
+const normalizeBeneficiarySortBy = (value: unknown) => {
+  switch (value) {
+    case 'firstName':
+      return 'first_name';
+    case 'lastName':
+      return 'last_name';
+    case 'createdAt':
+      return 'created_at';
+    case 'first_name':
+    case 'last_name':
+    case 'email':
+    case 'created_at':
+      return value;
+    default:
+      return 'created_at';
+  }
+};
+
 export const beneficiarySchema = z.object({
   id: z.string().uuid().optional(),
   first_name: z.string().min(1, 'First name is required').max(100),
@@ -24,12 +92,20 @@ export const createBeneficiarySchema = beneficiarySchema.omit({
 export const updateBeneficiarySchema = createBeneficiarySchema.partial();
 
 export const listBeneficiariesQuerySchema = z.object({
-  page: z.string().optional().default('1').transform(Number),
-  limit: z.string().optional().default('10').transform(Number),
-  sortBy: z.string().optional().default('created_at'),
-  sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
-  search: z.string().optional(),
-});
+  page: positiveIntQueryParam('page', 1),
+  limit: positiveIntQueryParam('limit', 10, 100),
+  sortBy: beneficiarySortByQueryParam,
+  sort_by: beneficiarySortByQueryParam,
+  sortOrder: sortOrderQueryParam,
+  sort_order: sortOrderQueryParam,
+  search: searchQueryParam,
+}).transform((query) => ({
+  page: query.page,
+  limit: query.limit,
+  sortBy: normalizeBeneficiarySortBy(query.sortBy ?? query.sort_by ?? 'created_at'),
+  sortOrder: query.sortOrder ?? query.sort_order ?? 'desc',
+  search: query.search,
+}));
 
 export type Beneficiary = z.infer<typeof beneficiarySchema>;
 export type CreateBeneficiaryInput = z.infer<typeof createBeneficiarySchema>;

--- a/apps/api/src/models/creditDispute.schema.ts
+++ b/apps/api/src/models/creditDispute.schema.ts
@@ -1,5 +1,67 @@
 import { z } from 'zod';
 
+const normalizeQueryValue = (value: unknown) => {
+  const normalized = Array.isArray(value) ? value[0] : value;
+  return typeof normalized === 'string' ? normalized.trim() : normalized;
+};
+
+const positiveIntQueryParam = (fieldName: string, defaultValue: number, max?: number) => {
+  const baseSchema = z.number().int(`${fieldName} must be an integer`).min(1, `${fieldName} must be at least 1`);
+  const boundedSchema = typeof max === 'number'
+    ? baseSchema.max(max, `${fieldName} must be at most ${max}`)
+    : baseSchema;
+
+  return z.preprocess((value) => {
+    const normalized = normalizeQueryValue(value);
+
+    if (normalized === undefined || normalized === null || normalized === '') {
+      return defaultValue;
+    }
+
+    if (typeof normalized === 'number' && Number.isInteger(normalized)) {
+      return normalized;
+    }
+
+    if (typeof normalized === 'string' && /^\d+$/.test(normalized)) {
+      return Number.parseInt(normalized, 10);
+    }
+
+    return Number.NaN;
+  }, boundedSchema);
+};
+
+const sortOrderQueryParam = z.preprocess((value) => {
+  const normalized = normalizeQueryValue(value);
+  return typeof normalized === 'string' ? normalized.toLowerCase() : normalized;
+}, z.enum(['asc', 'desc']).optional());
+
+const creditDisputeSortByQueryParam = z.preprocess(normalizeQueryValue, z.enum([
+  'status',
+  'created_at',
+  'createdAt',
+]).optional());
+
+const disputeStatusQueryParam = z.preprocess((value) => {
+  const normalized = normalizeQueryValue(value);
+  return typeof normalized === 'string' ? normalized.toLowerCase() : normalized;
+}, z.enum(['pending', 'submitted', 'investigating', 'resolved', 'rejected']).optional());
+
+const beneficiaryIdQueryParam = z.preprocess((value) => {
+  const normalized = normalizeQueryValue(value);
+  return normalized === '' ? undefined : normalized;
+}, z.string().uuid().optional());
+
+const normalizeCreditDisputeSortBy = (value: unknown) => {
+  switch (value) {
+    case 'status':
+      return 'status';
+    case 'createdAt':
+    case 'created_at':
+    default:
+      return 'created_at';
+  }
+};
+
 export const creditDisputeSchema = z.object({
   id: z.string().uuid().optional(),
   beneficiary_id: z.string().uuid('Invalid beneficiary ID'),
@@ -25,13 +87,23 @@ export const createCreditDisputeSchema = creditDisputeSchema.omit({
 export const updateCreditDisputeSchema = createCreditDisputeSchema.partial().omit({ beneficiary_id: true });
 
 export const listCreditDisputesQuerySchema = z.object({
-  page: z.string().optional().default('1').transform(Number),
-  limit: z.string().optional().default('10').transform(Number),
-  sortBy: z.string().optional().default('created_at'),
-  sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
-  status: z.enum(['pending', 'submitted', 'investigating', 'resolved', 'rejected']).optional(),
-  beneficiary_id: z.string().uuid().optional(),
-});
+  page: positiveIntQueryParam('page', 1),
+  limit: positiveIntQueryParam('limit', 10, 100),
+  sortBy: creditDisputeSortByQueryParam,
+  sort_by: creditDisputeSortByQueryParam,
+  sortOrder: sortOrderQueryParam,
+  sort_order: sortOrderQueryParam,
+  status: disputeStatusQueryParam,
+  beneficiary_id: beneficiaryIdQueryParam,
+  beneficiaryId: beneficiaryIdQueryParam,
+}).transform((query) => ({
+  page: query.page,
+  limit: query.limit,
+  sortBy: normalizeCreditDisputeSortBy(query.sortBy ?? query.sort_by ?? 'created_at'),
+  sortOrder: query.sortOrder ?? query.sort_order ?? 'desc',
+  status: query.status,
+  beneficiary_id: query.beneficiary_id ?? query.beneficiaryId,
+}));
 
 export type CreditDispute = z.infer<typeof creditDisputeSchema>;
 export type CreateCreditDisputeInput = z.infer<typeof createCreditDisputeSchema>;


### PR DESCRIPTION
## Summary
- harden `apps/api` list query parsing for beneficiaries and credit disputes
- reject malformed `page` and `limit` values instead of blindly using `transform(Number)`
- normalize camelCase and snake_case query aliases to the canonical service shape

## Evidence
- `apps/api/src/models/beneficiary.schema.ts` and `apps/api/src/models/creditDispute.schema.ts` previously used raw `z.string().optional().default(...).transform(Number)` for `page` and `limit`
- controllers parse `req.query` directly through these schemas before passing results into list services
- current branch diff vs `master` is limited to 2 files in `apps/api/src/models`

## What changed
- add positive integer guards for `page`
- add bounded positive integer guards for `limit` with max 100
- accept and normalize:
  - `sortBy` / `sort_by`
  - `sortOrder` / `sort_order`
  - `beneficiaryId` / `beneficiary_id` on credit disputes
- normalize common camelCase sort aliases such as `createdAt`, `firstName`, and `lastName`

## Verification
- branch is ahead of `master` by 1 commit and behind by 0
- changed files:
  - `apps/api/src/models/beneficiary.schema.ts`
  - `apps/api/src/models/creditDispute.schema.ts`
- no local build/typecheck was run from this environment because the repository working tree is not mounted here

## Risk
- low to moderate
- behavior is intentionally stricter for malformed numeric query params, so callers sending junk like `page=abc` will now receive validation errors instead of falling through with `NaN`
